### PR TITLE
feat: change default behaviour

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,8 +55,11 @@ class GetStarknetWallet implements IGetStarknetWallet {
             // force showing the popup if
             // 1. we are called while connected
             // 2. we were explicitly told to show it
-            // 3. user never selected from the popup
-            const forcePopup = connected || options?.showList || !lastWallet;
+            // 3. user never selected from the popup AND has more than one wallet
+            const forcePopup =
+                connected ||
+                options?.showList ||
+                (!lastWallet && installedWallets.length > 1);
             if (!forcePopup) {
                 // return user-set default wallet if available
                 for (const stateWallet of [


### PR DESCRIPTION
this PR aims to change the default behaviour of the package:

In case the package gets called the first time ever in a dapp **and** only one wallet is installed **instead** of showing a list with one wallet installed + discovery, **replace by** picking the one installed wallet by default.
This is the default behaviour in @argent/get-starknet currently and doesnt force the user to do one additional step on every initial dapp usage.