### PR TITLE
chore(docs): use diff syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,11 @@ yarn add get-starknet
 
 If you were using getStarknet() before, simply replace the import line as below.
 
-before -
-```js
-import { getStarknet } from "@argent/get-starknet"
+```diff
+-import { getStarknet } from "@argent/get-starknet"
++import { getStarknet } from "get-starknet"
 ```
-now -
-```js
-import { getStarknet } from "get-starknet"
-```
+
 - Optional - customize the CSS of get-starknet to match your look&amp;feel
 - Optional - integrate with new API functions (e.g.: modify wallet list using custom sort/include/exclude, etc.)
 


### PR DESCRIPTION
This is a totally optional minor improvement to the README. It's possible to render git diffs in Markdown by using ```diff which will look like:

### Screenshot

<img width="847" alt="Screen Shot 2022-04-28 at 4 36 22 PM" src="https://user-images.githubusercontent.com/3699047/165777538-84623be6-0669-48d6-816e-4332e1968d44.png">

