### PR TITLE
refactor: future-proof `getInstalledWallets`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -271,7 +271,9 @@ class GetStarknetWallet implements IGetStarknetWallet {
 
         // lookup installed wallets
         const installed = Object.values(
-            Object.getOwnPropertyNames(window).reduce((wallets, key) => {
+            Object.getOwnPropertyNames(window).reduce<
+                Record<string, IStarknetWindowObject>
+            >((wallets, key) => {
                 if (key.startsWith("starknet")) {
                     const wallet = (window as Record<string, any>)[key];
                     if (isWalletObj(key, wallet) && !wallets[wallet.id]) {
@@ -279,7 +281,7 @@ class GetStarknetWallet implements IGetStarknetWallet {
                     }
                 }
                 return wallets;
-            }, {} as Record<string, IStarknetWindowObject>)
+            }, {})
         );
 
         // 1. lookup state wallets

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,17 +271,15 @@ class GetStarknetWallet implements IGetStarknetWallet {
 
         // lookup installed wallets
         const installed = Object.values(
-            ["starknet", "starknet_braavos", ...Object.keys(window)].reduce<{
-                [key: string]: IStarknetWindowObject;
-            }>((wallets, key) => {
+            Object.getOwnPropertyNames(window).reduce((wallets, key) => {
                 if (key.startsWith("starknet")) {
-                    const wallet = (window as { [key: string]: any })[key];
+                    const wallet = (window as Record<string, any>)[key];
                     if (isWalletObj(key, wallet) && !wallets[wallet.id]) {
                         wallets[wallet.id] = wallet;
                     }
                 }
                 return wallets;
-            }, {})
+            }, {} as Record<string, IStarknetWindowObject>)
         );
 
         // 1. lookup state wallets


### PR DESCRIPTION
Future starknet wallets should be automatically handled using this method, independent of the way they're set on the `window` object.

A question remains: what if multiple wallets don't define an `id`? Currently only one of them would be keyed as "undefined" in this `wallets` object, overwriting the others. Since the key set on `window` is already unique for each wallet, why not use that as identifier?