### PR TITLE
fix: getInstalledWallets now support using this keyword

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -250,9 +250,9 @@ class GetStarknetWallet implements IGetStarknetWallet {
         );
     };
 
-    getInstalledWallets(
+    getInstalledWallets = (
         options?: Omit<GetStarknetWalletOptions, "showList" | "modalOptions">
-    ): Promise<IStarknetWindowObject[]> {
+    ): Promise<IStarknetWindowObject[]> => {
         return this.#getInstalledWallets(options).then(res => res.installed);
     }
 


### PR DESCRIPTION
Because of the way the function was declared, it didn't have access to `this`