### PR TITLE
feat: change Provider to ProviderInterface in IStarknetWindowObject

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,11 @@ import {
     AccountInterface,
     defaultProvider,
     KeyPair,
+    ProviderInterface,
     SignerInterface,
 } from "starknet";
 
+import 
 class GetStarknetWallet implements IGetStarknetWallet {
     #walletObjRef: { current?: IStarknetWindowObject } = {};
 
@@ -116,7 +118,7 @@ class GetStarknetWallet implements IGetStarknetWallet {
                 name = "Disconnected";
                 icon = "";
                 selectedAddress?: string = undefined;
-                provider = defaultProvider;
+                provider: ProviderInterface = defaultProvider;
                 isConnected = false;
                 account: AccountInterface = new Account(
                     defaultProvider,
@@ -254,7 +256,7 @@ class GetStarknetWallet implements IGetStarknetWallet {
         options?: Omit<GetStarknetWalletOptions, "showList" | "modalOptions">
     ): Promise<IStarknetWindowObject[]> => {
         return this.#getInstalledWallets(options).then(res => res.installed);
-    }
+    };
 
     #isConnected(): boolean {
         return !!this.#walletObjRef.current;

--- a/src/index.ts
+++ b/src/index.ts
@@ -255,7 +255,7 @@ class GetStarknetWallet implements IGetStarknetWallet {
         options?: Omit<GetStarknetWalletOptions, "showList" | "modalOptions">
     ): Promise<IStarknetWindowObject[]> => {
         return this.#getInstalledWallets(options).then(res => res.installed);
-    };
+    }
 
     #isConnected(): boolean {
         return !!this.#walletObjRef.current;

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,6 @@ import {
     SignerInterface,
 } from "starknet";
 
-import 
 class GetStarknetWallet implements IGetStarknetWallet {
     #walletObjRef: { current?: IStarknetWindowObject } = {};
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,7 +114,7 @@ export interface IGetStarknetWallet {
     getStarknet(): IStarknetWindowObject;
 }
 
-import type { AccountInterface, Provider, SignerInterface } from "starknet";
+import type { AccountInterface, ProviderInterface, SignerInterface } from "starknet";
 
 export type EventType = "accountsChanged" | "networkChanged";
 
@@ -156,7 +156,7 @@ export interface IStarknetWindowObject {
     name: string;
     version: string;
     icon: string;
-    provider: Provider;
+    provider: ProviderInterface;
     isConnected: boolean;
     /**
      * @deprecated use `account` instead


### PR DESCRIPTION
That would make more sense if we replace the type of `provider` in IStarknetWindowObject to ProviderInterface instead of Provider. I assume there is a reason why it has not been done because the account already relies on the interface! Can you explain? If you have the need to a specific method which does not look to be the case since the project compile that would make sense to add it to the interface in starknet.js. I am working on an implementation of a StarknetWindowObject and relying on the defaultProvider inflates my artefact. Thank you for your feedback.