### PR TITLE
[codex] Backport npm trusted publishing to master

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,18 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 8
 
       - name: setup node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           cache: "pnpm"
 
       - name: install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,29 +6,34 @@ on:
       - master
       - develop
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   version:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: checkout code repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 8
 
       - name: setup node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
-      - name: Setup npmrc
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_ACCESS_TOKEN }}" >> .npmrc
+      - name: update npm cli
+        run: npm install -g npm@11
 
       - name: install dependencies
         run: pnpm install

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,11 @@
     "wallet",
     "dapp"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/starknet-io/get-starknet.git",
+    "directory": "packages/core"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,11 @@
     "wallet",
     "dapp"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/starknet-io/get-starknet.git",
+    "directory": "packages/ui"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Backports the release infrastructure changes needed for npm trusted publishing on the master release line without merging the v6 develop branch.

- updates release and PR workflows to Node 24-compatible GitHub actions
- switches the master release workflow from npm token auth to OIDC trusted publishing
- adds package repository metadata for the two master packages npm needs to match trusted publishing

## Validation

- ruby YAML parse for .github/workflows/release.yml and .github/workflows/pr.yml
- node JSON parse for package manifests
- git diff --check
- direct Prettier 2.8.8 check for the changed files

Note: full `pnpm format:check` could not be run locally because this workstation injects a pnpm/npm `only-built-dependencies` config that pnpm 8 cannot parse during install. The direct Prettier check covered the changed files.

## Before merge

Ensure npm trusted publishing is configured for:

- @starknet-io/get-starknet-core
- @starknet-io/get-starknet

Using: starknet-io / get-starknet / release.yml / npm publish / no environment.