### PR TITLE
chore: update @starknet-io/types-js to 0.10.4-beta.2

### DIFF
--- a/.changeset/update-types-js-0-10-4-beta-2.md
+++ b/.changeset/update-types-js-0-10-4-beta-2.md
@@ -1,0 +1,7 @@
+---
+"@starknet-io/get-starknet-wallet-standard": patch
+"@starknet-io/get-starknet-virtual-wallet": patch
+"@starknet-io/get-starknet-discovery": patch
+---
+
+Update @starknet-io/types-js to 0.10.4-beta.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@starknet-io/types-js':
-      specifier: 0.10.4-beta.1
-      version: 0.10.4-beta.1
+      specifier: 0.10.4-beta.2
+      version: 0.10.4-beta.2
     tsdown:
       specifier: ^0.21.9
       version: 0.21.9
@@ -89,7 +89,7 @@ importers:
     devDependencies:
       '@starknet-io/types-js':
         specifier: 'catalog:'
-        version: 0.10.4-beta.1
+        version: 0.10.4-beta.2
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -129,7 +129,7 @@ importers:
         version: link:../wallet-standard
       '@starknet-io/types-js':
         specifier: 'catalog:'
-        version: 0.10.4-beta.1
+        version: 0.10.4-beta.2
       '@wallet-standard/base':
         specifier: ^1.1.1
         version: 1.1.1
@@ -267,7 +267,7 @@ importers:
         version: link:../wallet-standard
       '@starknet-io/types-js':
         specifier: 'catalog:'
-        version: 0.10.4-beta.1
+        version: 0.10.4-beta.2
       '@wallet-standard/base':
         specifier: ^1.1.1
         version: 1.1.1
@@ -295,7 +295,7 @@ importers:
     dependencies:
       '@starknet-io/types-js':
         specifier: 'catalog:'
-        version: 0.10.4-beta.1
+        version: 0.10.4-beta.2
       '@wallet-standard/base':
         specifier: ^1.1.1
         version: 1.1.1
@@ -2356,8 +2356,8 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
-  '@starknet-io/types-js@0.10.4-beta.1':
-    resolution: {integrity: sha512-5OU+PEX+/0/8iqOyO3/7fErQUXfRbgA5gEdvoSLmgNxUkJ5wbKDqtNwA0guyZfI60J0rKcBbmVcnP3aXKqOr2w==}
+  '@starknet-io/types-js@0.10.4-beta.2':
+    resolution: {integrity: sha512-DHfzg/d6s1NYeQpbBpLwXxYBVgCMhMIW2RjbSS2ukwz8XbPZQCLwj8ArAH4Tx4dmkJpn4J6YVRhZGFgjO26TVQ==}
 
   '@tailwindcss/cli@4.3.0':
     resolution: {integrity: sha512-X9kdlqyMopO9fewbgHsEeuy31YzMHbdZ9VsKt004tB+mxSg1CNbyhZYCzvhciN0AM4R4b5lvIprPjtNq7iQxpQ==}
@@ -7652,7 +7652,7 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
-  '@starknet-io/types-js@0.10.4-beta.1': {}
+  '@starknet-io/types-js@0.10.4-beta.2': {}
 
   '@tailwindcss/cli@4.3.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ onlyBuiltDependencies:
   - "@tailwindcss/oxide"
   - esbuild
 catalog:
-  "@starknet-io/types-js": "0.10.4-beta.1"
+  "@starknet-io/types-js": "0.10.4-beta.2"
   tsdown: ^0.21.9
   typescript: ^5.9.3
   vitest: ^3.2.6


### PR DESCRIPTION
## Summary
- update the workspace catalog to `@starknet-io/types-js` `0.10.4-beta.2`
- refresh the pnpm lockfile
- correct the pending changeset release note

## Validation
- `pnpm typecheck`