### PR TITLE
docs: fix the core Advanced usage example (interface + imports)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,12 @@ custom UI, you can use the `core` package.
 ```tsx
 import {
   disconnect,
+  discoverVirtualWallets,
   enable,
+  getAuthorizedWallets,
   getAvailableWallets,
   getDiscoveryWallets,
   getLastConnectedWallet,
-  getPreAuthorizedWallets,
 } from "@starknet-io/get-starknet-core"
 
 interface GetStarknetResult {
@@ -60,22 +61,22 @@ interface GetStarknetResult {
     options?: GetWalletOptions,
   ) => Promise<StarknetWindowObject[]>
   // Returns only preauthorized wallets available in the window object
-  getPreAuthorizedWallets: (
+  getAuthorizedWallets: (
     options?: GetWalletOptions,
   ) => Promise<StarknetWindowObject[]>
   // Returns all wallets in existence (from discovery file)
   getDiscoveryWallets: (options?: GetWalletOptions) => Promise<WalletProvider[]>
   // Returns the last wallet connected when it's still connected
-  getLastConnectedWallet: () => Promise<StarknetWindowObject | null>
+  getLastConnectedWallet: () => Promise<StarknetWindowObject | null | undefined>
+  // Discovers the virtual wallets by calling their hasSupport methods
+  discoverVirtualWallets: () => Promise<void>
   // Connects to a wallet
   enable: (
-    wallet: StarknetWindowObject,
-    options?: {
-      starknetVersion?: "v4" | "v5"
-    },
-  ) => Promise<ConnectedStarknetWindowObject>
+    wallet: StarknetWindowObject | VirtualWallet,
+    options?: RequestAccountsParameters,
+  ) => Promise<StarknetWindowObject>
   // Disconnects from a wallet
-  disconnect: (options?: { clearLastWallet?: boolean }) => Promise<void>
+  disconnect: (options?: DisconnectOptions) => Promise<void>
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,16 +45,22 @@ implementing your very own UI. This is possible due to a split into a `core` and
 custom UI, you can use the `core` package.
 
 ```tsx
-import {
-  disconnect,
-  discoverVirtualWallets,
-  enable,
-  getAuthorizedWallets,
+import { getStarknet } from "@starknet-io/get-starknet-core"
+
+// `@starknet-io/get-starknet-core` exports the `getStarknet()` factory (and a
+// default, ready-to-use instance). The methods below live on the object it
+// returns, they are not named exports of the package:
+const {
   getAvailableWallets,
+  getAuthorizedWallets,
   getDiscoveryWallets,
   getLastConnectedWallet,
-} from "@starknet-io/get-starknet-core"
+  discoverVirtualWallets,
+  enable,
+  disconnect,
+} = getStarknet()
 
+// The returned object implements GetStarknetResult:
 interface GetStarknetResult {
   // Returns all wallets available in the window object
   getAvailableWallets: (


### PR DESCRIPTION
closes #324
closes #328

## what

The README's "Advanced usage" `core` example had two separate problems, both fixed here.

### 1. `GetStarknetResult` interface drift (#324)

The documented interface had drifted from the `core` implementation, so TypeScript users could implement against methods and options that no longer exist. Reconcile it against `packages/core/src/types.ts`:

- `getPreAuthorizedWallets` -> `getAuthorizedWallets`
- `getLastConnectedWallet` return type -> `Promise<StarknetWindowObject | null | undefined>`
- add the missing `discoverVirtualWallets: () => Promise<void>`
- `enable`: `wallet` accepts `StarknetWindowObject | VirtualWallet`, `options` is `RequestAccountsParameters` (was an obsolete `{ starknetVersion?: "v4" | "v5" }`), returns `StarknetWindowObject` (was the obsolete `ConnectedStarknetWindowObject`)
- `disconnect`: use the named `DisconnectOptions` instead of an inline shape, so it cannot drift again

### 2. Non-existent named imports (#328)

The same example imported `enable`, `disconnect`, `getAvailableWallets` and the rest as named exports of `@starknet-io/get-starknet-core`, but the package only exports the `getStarknet()` factory (and a default instance) - those methods live on the object `getStarknet()` returns, so the snippet did not resolve as written. Import `getStarknet` and destructure the methods off its result.

The documented comments are kept verbatim from the source interface. README-only change; prettier passes.