### PR TITLE
fix(core): stop LocalStorageWrapper rotating its key and mutating on read

### DIFF
--- a/packages/core/src/__test__/localStorageStore.test.ts
+++ b/packages/core/src/__test__/localStorageStore.test.ts
@@ -1,0 +1,64 @@
+import { LocalStorageWrapper } from "../localStorageStore"
+import { beforeEach, describe, expect, it } from "vitest"
+
+const KEY = "gsw-last"
+
+function storageKeys(prefix = KEY): string[] {
+  const keys: string[] = []
+  for (let i = 0; i < localStorage.length; i++) {
+    const k = localStorage.key(i)
+    if (k && k.startsWith(prefix)) keys.push(k)
+  }
+  return keys.sort()
+}
+
+describe("LocalStorageWrapper", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it("stores the value under a single stable key", () => {
+    const store = new LocalStorageWrapper(KEY)
+    store.set("braavos")
+    expect(localStorage.getItem(KEY)).toBe("braavos")
+    expect(store.get()).toBe("braavos")
+  })
+
+  it("does not accumulate duplicate keys across repeated sets", () => {
+    const store = new LocalStorageWrapper(KEY)
+    store.set("argentX")
+    store.set("braavos")
+    store.set("okx")
+    expect(storageKeys()).toEqual([KEY])
+    expect(store.get()).toBe("okx")
+  })
+
+  it("get() does not rotate or mutate storage on read", () => {
+    const store = new LocalStorageWrapper(KEY)
+    store.set("braavos")
+    const keysBefore = storageKeys()
+    // read repeatedly, the way a React effect polling getLastConnectedWallet would
+    store.get()
+    store.get()
+    expect(storageKeys()).toEqual(keysBefore)
+    expect(localStorage.getItem(KEY)).toBe("braavos")
+    expect(store.get()).toBe("braavos")
+  })
+
+  it("migrates a legacy rotated `${key}-<uid>` entry to the stable key", () => {
+    localStorage.setItem(`${KEY}-abc123`, "braavos")
+    const store = new LocalStorageWrapper(KEY)
+    expect(store.get()).toBe("braavos")
+    expect(localStorage.getItem(KEY)).toBe("braavos")
+    expect(localStorage.getItem(`${KEY}-abc123`)).toBe(null)
+    expect(storageKeys()).toEqual([KEY])
+  })
+
+  it("delete() removes the stored value", () => {
+    const store = new LocalStorageWrapper(KEY)
+    store.set("braavos")
+    store.delete()
+    expect(localStorage.getItem(KEY)).toBe(null)
+    expect(store.get()).toBeFalsy()
+  })
+})

--- a/packages/core/src/localStorageStore.ts
+++ b/packages/core/src/localStorageStore.ts
@@ -1,5 +1,3 @@
-import { generateUID } from "./utils"
-
 export interface IStorageWrapper {
   set(value: string | null | undefined): boolean
   get(): string | null | undefined
@@ -8,12 +6,11 @@ export interface IStorageWrapper {
 
 export class LocalStorageWrapper implements IStorageWrapper {
   #initialized = false
-  #key: string | undefined = undefined
-  #prefix: string
+  #key: string
   value: string | null | undefined = undefined
 
   constructor(key: string) {
-    this.#prefix = key
+    this.#key = key
 
     this.#init()
   }
@@ -23,19 +20,17 @@ export class LocalStorageWrapper implements IStorageWrapper {
       return false
     }
 
-    this.delete() // clear current key
-
     this.value = value
     if (value) {
-      this.#key = `${this.#prefix}-${generateUID()}`
       localStorage.setItem(this.#key, value)
+    } else {
+      localStorage.removeItem(this.#key)
     }
 
     return true
   }
 
   get() {
-    this.#validateValue()
     return this.value
   }
 
@@ -45,31 +40,38 @@ export class LocalStorageWrapper implements IStorageWrapper {
     }
 
     this.value = null
-    if (this.#key) localStorage.removeItem(this.#key)
+    localStorage.removeItem(this.#key)
 
     return true
-  }
-
-  #validateValue() {
-    if (this.value) {
-      this.set(this.value)
-    }
   }
 
   #init() {
     try {
       if (!this.#initialized && typeof window !== "undefined") {
-        // init with prev key/value
-        this.#key = Object.keys(localStorage).find((sk) =>
-          sk.startsWith(this.#prefix),
-        )
-
-        // set initialized as soon as we managed to extract data
-        // from localStorage, so the `set` call below won't result
-        // in a endless-recursive loop
+        // set initialized before touching storage so a re-entrant call
+        // cannot recurse back into #init
         this.#initialized = true
-        if (this.#key) {
-          this.set(localStorage.getItem(this.#key))
+
+        // Older versions stored the value under a rotating `${key}-<uid>`
+        // key and rewrote it on every read, which could leave several
+        // duplicate entries and make the "last connected wallet" lookup
+        // non-deterministic. Migrate any such legacy keys into the single
+        // stable key and drop the duplicates.
+        const legacyKeys: string[] = []
+        for (let i = 0; i < localStorage.length; i++) {
+          const sk = localStorage.key(i)
+          if (sk && sk !== this.#key && sk.startsWith(`${this.#key}-`)) {
+            legacyKeys.push(sk)
+          }
+        }
+        const existing =
+          localStorage.getItem(this.#key) ??
+          (legacyKeys.length > 0 ? localStorage.getItem(legacyKeys[0]) : null)
+        legacyKeys.forEach((sk) => localStorage.removeItem(sk))
+
+        if (existing != null) {
+          this.value = existing
+          localStorage.setItem(this.#key, existing)
         }
       }
     } catch (err) {


### PR DESCRIPTION
closes #204

## what

`LocalStorageWrapper` is the default store behind `getLastConnectedWallet()`. It stored its value under a rotating `${key}-<uid>` key and regenerated the uid on every `set()`. Worse, `get()` ran a `#validateValue()` step that called `set()` again, so a plain read rewrote the entry under a fresh key.

Reading `getLastConnectedWallet()` from an async context (e.g. a React `useEffect`) therefore raced against itself: reads and writes each rotated the key, and interleaving could leave several `gsw-last-<uid>` entries behind, making the last-connected lookup non-deterministic.

## how

Use a single stable key:

- `set()` writes/clears the stable key, `get()` is now pure (no storage mutation on read), `delete()` clears it.
- `#init()` migrates any legacy `${key}-<uid>` entries written by older versions into the stable key and drops the duplicates, so existing users keep their last-connected wallet across the upgrade.
- the migration scan uses the Storage `length`/`key(i)` API instead of `Object.keys(localStorage)` (the latter is not a reliable way to enumerate a `Storage` object - it returns nothing under happy-dom, and is not guaranteed in general).

No key rotation means duplicates can no longer accumulate, and a read can no longer clobber the stored value.

## tests

Added `packages/core/src/__test__/localStorageStore.test.ts` exercising the real `LocalStorageWrapper` (the existing suite only covered the mock): stable key, no duplicate accumulation across repeated sets, read purity, and legacy-key migration. All four fail against the previous implementation. Full `core` suite: 42 tests pass.
