### PR TITLE
fix(core): sortBy mis-orders wallets when `sort` lists uninstalled ids

### DIFF
--- a/packages/core/src/__test__/sort.test.ts
+++ b/packages/core/src/__test__/sort.test.ts
@@ -1,0 +1,25 @@
+import { sortBy } from "../wallet/sort"
+import { describe, expect, it } from "vitest"
+
+const wallet = (id: string) => ({ id } as any)
+
+describe("sortBy", () => {
+  it("orders wallets named in `sort` first, in the given order, ignoring uninstalled ids", () => {
+    // "ghost" is not installed; "c" and "a" are, listed out of natural order
+    const result = sortBy(
+      [wallet("a"), wallet("b"), wallet("c")],
+      ["ghost", "c", "a"],
+    )
+    // c then a (their order in `sort`), then the unsorted remainder
+    expect(result.slice(0, 2).map((w) => w.id)).toEqual(["c", "a"])
+    expect(result.slice(2).map((w) => w.id)).toEqual(["b"])
+  })
+
+  it("prioritises a single installed match among uninstalled ids", () => {
+    // regression: before the fix `a` ended up last because `sort.length` (2)
+    // exceeded the number of installed matches (1)
+    const result = sortBy([wallet("a"), wallet("b")], ["ghost", "a"])
+    expect(result[0].id).toBe("a")
+    expect(result.slice(1).map((w) => w.id)).toEqual(["b"])
+  })
+})

--- a/packages/core/src/wallet/sort.ts
+++ b/packages/core/src/wallet/sort.ts
@@ -13,7 +13,12 @@ export const sortBy = <T extends StarknetWindowObject | WalletProvider>(
     // sort by client-specific order
     wallets.sort((a, b) => sort.indexOf(a.id) - sort.indexOf(b.id))
 
-    const sortScope = wallets.length - sort.length
+    // count only the wallets that are actually installed and named in `sort`;
+    // `sort` may list ids the user does not have, and those must not shift the
+    // split between the sorted and shuffled groups
+    const sortScope =
+      wallets.length -
+      wallets.filter((wallet) => sort.includes(wallet.id)).length
     return [
       ...wallets.slice(sortScope),
       // shuffle wallets which are outside `sort` scope


### PR DESCRIPTION
## what

`getAvailableWallets({ sort })` lets a dapp pass a preferred wallet order. `sortBy` mis-orders the result when `sort` names wallets the user does not have installed, pushing an explicitly-prioritised wallet to the back.

## why

```ts
wallets.sort((a, b) => sort.indexOf(a.id) - sort.indexOf(b.id))
const sortScope = wallets.length - sort.length   // assumes every id in `sort` is installed
return [...wallets.slice(sortScope), ...shuffle(wallets.slice(0, sortScope))]
```

After the comparator, in-`sort` wallets sit at the tail (uninstalled ids resolve to `indexOf === -1` and sort first). The split keeps the last `sort.length` as the ordered group, but that only holds if every id in `sort` maps to an installed wallet.

Concrete: installed `["a", "b"]`, call with `sort: ["ghost", "a"]`. Comparator gives `["b", "a"]`; `sortScope = 2 - 2 = 0`; result is `["b", "a"]`, so the prioritised `a` ends up last instead of first. This is a common input: a dapp lists several preferred wallets and the user only has one.

Found by reading through the sort path; the existing "should sort wallets" tests only pass fully-installed sort lists, so this was uncovered.

## how

Compute the split from the number of installed wallets actually named in `sort`:

```ts
const sortScope = wallets.length - wallets.filter((wallet) => sort.includes(wallet.id)).length
```

Adds `sort.test.ts` covering the uninstalled-id cases. `core` tests pass (30), prettier and tsc clean.
