### PR TITLE
fix(core): metaMask retry recursion drops the real windowObject

### DIFF
--- a/.changeset/fix-metamask-retry-windowobject.md
+++ b/.changeset/fix-metamask-retry-windowobject.md
@@ -1,0 +1,9 @@
+---
+"@starknet-io/get-starknet-core": patch
+---
+
+Fix waitForMetaMaskProvider's retry recursion dropping the real windowObject
+argument (it was passing the options object as windowObject instead), so every
+retry attempt silently listened on a non-functional object instead of the real
+window. Also restores the requested retry count, which was resetting to 0 on
+each recursive call.

--- a/packages/core/src/__test__/metaMaskVirtualWallet.test.ts
+++ b/packages/core/src/__test__/metaMaskVirtualWallet.test.ts
@@ -1,0 +1,55 @@
+import { metaMaskVirtualWallet } from "../wallet/virtualWallets/metaMaskVirtualWallet"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// This installed vitest (0.19.1) predates vi.advanceTimersByTimeAsync, so timer
+// advances and the microtask chain they release (promise resolution walking back
+// up through detectMetaMaskProvider -> waitForMetaMaskProvider -> the next
+// recursive call's own setTimeout registration) must be interleaved by hand: a
+// real setImmediate macrotask only runs once every currently-queued microtask has
+// drained, which is exactly the flush point we need before the next timer tick.
+function flushMicrotasks() {
+  return new Promise<void>((resolve) => setImmediate(resolve))
+}
+
+async function tick(ms: number) {
+  vi.advanceTimersByTime(ms)
+  await flushMicrotasks()
+  await flushMicrotasks()
+}
+
+describe("MetaMaskVirtualWallet retries", () => {
+  beforeEach(() => {
+    // Only fake setTimeout/clearTimeout - leave setImmediate real so it can be
+    // used below as a microtask-queue flush point between timer advances.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("passes the real windowObject through on every retry attempt", async () => {
+    const addEventListener = vi.fn()
+    const dispatchEvent = vi.fn()
+    const fakeWindowObject = { addEventListener, dispatchEvent }
+
+    const resultPromise = metaMaskVirtualWallet.hasSupport(fakeWindowObject)
+
+    // detectMetamaskSupport calls waitForMetaMaskProvider(windowObject, { retries: 3 }),
+    // so a correct implementation makes 1 initial attempt + 3 retries, each waiting
+    // out the default 3000ms timeout since no provider ever announces itself.
+    for (let attempt = 0; attempt < 4; attempt++) {
+      await tick(3000)
+    }
+
+    const result = await resultPromise
+
+    expect(result).toBe(false)
+    // If the recursive call drops the real windowObject (passing the
+    // `{ timeout, retries }` options object as windowObject instead), only the
+    // very first attempt has a real addEventListener/dispatchEvent to call -
+    // every retry hits a plain object with no such methods.
+    expect(addEventListener).toHaveBeenCalledTimes(4)
+    expect(dispatchEvent).toHaveBeenCalledTimes(4)
+  })
+})

--- a/packages/core/src/wallet/virtualWallets/metaMaskVirtualWallet.ts
+++ b/packages/core/src/wallet/virtualWallets/metaMaskVirtualWallet.ts
@@ -79,7 +79,10 @@ async function waitForMetaMaskProvider(
     return null
   }
 
-  provider = await waitForMetaMaskProvider({ timeout, retries: retries - 1 })
+  provider = await waitForMetaMaskProvider(windowObject, {
+    timeout,
+    retries: retries - 1,
+  })
   return provider
 }
 


### PR DESCRIPTION
Found by inspection, no filed issue.

`waitForMetaMaskProvider`'s retry recursion had a typo that broke it two ways at
once:

```ts
provider = await waitForMetaMaskProvider({ timeout, retries: retries - 1 })
```

This passes the options object as the first argument (`windowObject`) and drops
the real `windowObject` entirely. Two compounding effects:

1. `windowObject` on every retry becomes `{ timeout, retries: retries - 1 }`, not
   the real `window`. `detectMetaMaskProvider` checks
   `typeof windowObject.addEventListener === "function"` /
   `typeof windowObject.dispatchEvent === "function"` before doing anything - both
   are false against that object, so a retry never actually listens for or
   requests an EIP-6963 provider announcement. It just waits out the timeout and
   resolves `null`.
2. Since `options` isn't passed on the recursive call, it defaults to `{}` inside
   that call, so `retries` also resets to its default of `0` - meaning
   `detectMetamaskSupport`'s `retries: 3` produced exactly one wasted attempt, not
   three.

Fix: pass both arguments through correctly -
`waitForMetaMaskProvider(windowObject, { timeout, retries: retries - 1 })`.

The old call still typechecked, since `{ timeout, retries }` is assignable to
`Record<string, unknown>` - that's how this survived.

## Behavior change, called out explicitly

With retries now actually reaching the real window, late-announcing MetaMask
extensions get caught in retry windows 2-4 instead of only the first. The cost:
when MetaMask isn't installed, worst case discovery time goes from ~6s (one real
3s attempt + one dead 3s retry) to ~12s (4 real 3s attempts). This is on an awaited
path - `discoverVirtualWallets` in `main.ts` does `Promise.all` over `hasSupport`,
so a dapp awaiting wallet discovery sees it settle ~6s later in the no-MetaMask
case. `initiateVirtualWallets` is fire-and-forget and unaffected. Installed-MetaMask
users are unaffected (the EIP-6963 announce resolves in ms either way). Restoring
the written intent (`retries: 3`) is the right default fix; if 12s worst-case is
too long, tuning `timeout`/`retries` is a separate, deliberate call for maintainers
to make.

## Base branch

Targeting `master`, not `develop`: this code path (and `waitForMetaMaskProvider`
itself) doesn't exist on `develop` - that's the v6 rewrite where wallet discovery
moved to `packages/virtual-wallet/src/metamask.ts` and is
wallet-standard/announce-driven. The bug only exists on the `master`/v4 line, which
is what's published as `latest` on npm.

## Testing

New test in `src/__test__/metaMaskVirtualWallet.test.ts`, driven through the real
exported entry point (`metaMaskVirtualWallet.hasSupport`, since
`waitForMetaMaskProvider` itself isn't exported). Uses fake timers (this repo's
installed vitest predates `advanceTimersByTimeAsync`, so a hand-rolled tick helper
advances the timer then flushes the microtask queue) to walk through all 4 attempts
(1 initial + `retries: 3`) and asserts a spy `windowObject`'s
`addEventListener`/`dispatchEvent` are each called 4 times - only possible if the
real object reaches every attempt.

Guard-validated: reverted the fix, confirmed the test fails at exactly 1 call
instead of 4 (matching the predicted defect - only the first real attempt reaches
the spy), restored, confirmed 4/4. Full core suite: 38/38 pass. `prettier --check`
clean on both files. `vite build` (which surfaces type errors via
`vite-plugin-dts`) clean, no type errors. Patch changeset added for
`@starknet-io/get-starknet-core` (linked with `@starknet-io/get-starknet` per
`.changeset/config.json`, so this one entry versions both).
